### PR TITLE
Iframe preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,12 +86,11 @@
 			</ul>
 		</form>
 
-		<div id="preview">
-				<div class="content">
-                    <iframe id="preview-frame" frameborder="0" style="border:solid #aaa 1px; width: 450px; height: 300px; background-color: #FFF; padding:0; margin:0"></iframe>
-				</div>
-		</div>
-		<div id="htmlCheck"></div>
+    <div id="preview">
+        <h4>Preview</h4>      
+        <iframe id="preview-frame" frameborder="0"></iframe>
+    </div>
+    <div id="htmlCheck"></div>
 
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -88,8 +88,7 @@
 
 		<div id="preview">
 				<div class="content">
-					<div class="well" id="previewBox">
-					</div>
+                    <iframe id="preview-frame" frameborder="0" style="border:solid #aaa 1px; width: 450px; height: 300px; background-color: #FFF; padding:0; margin:0"></iframe>
 				</div>
 		</div>
 		<div id="htmlCheck"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -43,6 +43,7 @@
     }
 
     function validateEmbedCode(embedCode, mute) {
+return true;
         if (allowUrl && isValidUrl(embedCode)) {
             return true;
         }
@@ -162,6 +163,14 @@
         if (!validateEmbedCode(html)) {
             return;
         }
+        if (html.indexOf('<script') > -1) {
+            html =  html.replace(/&amp;/g,'&').replace(/\&lt\;/g, '<').replace(/\&gt\;/g, '>');
+        }
+        var iframe = document.getElementById('preview-frame');
+        iframe.contentWindow.document.open();
+        iframe.contentWindow.document.write(html);
+        iframe.contentWindow.document.close();
+/*
         $("#previewBox").html(html).delay(500).fadeIn(500);
         if ($("#width").val()) {
             $("#previewBox").css({
@@ -175,6 +184,7 @@
                 "height": $("#height").val()
             });
         }
+*/
         instgrm.Embeds.process();
     }
 
@@ -238,7 +248,7 @@
         });
         PluginAPI.on('embeddedAssetBlur', function (event) {
             clear();
-            $("#previewBox").fadeOut(500).delay(500).html('');
+            //$("#previewBox").fadeOut(500).delay(500).html('');
         });
 
         if (allowUrl) {
@@ -295,7 +305,7 @@
         });
         $("#clearButton").on("click", function () {
             $('.alert').fadeOut(500);
-            $("#previewBox").fadeOut(500).delay(500).html('');
+            //$("#previewBox").fadeOut(500).delay(500).html('');
             clear();
         });
     });

--- a/sass/templates/main.scss
+++ b/sass/templates/main.scss
@@ -58,3 +58,26 @@ body {
 #previewButton {
   display: none;
 }
+
+#preview {
+  margin-left: -15px;
+  display: none;
+}
+
+#preview-frame { 
+  border: solid #aaa 1px;
+  width: 450px;
+  height: 300px;
+  background-color: #FFF;
+  padding: 0;
+  margin: 0;
+}
+
+h4 {
+  font-size: 1em;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+  margin-bottom: 5px;
+  padding: 0;
+}

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -71,3 +71,29 @@ body {
 #previewButton {
   display: none;
 }
+
+/* line 62, ../sass/templates/main.scss */
+#preview {
+  margin-left: -15px;
+  display: none;
+}
+
+/* line 67, ../sass/templates/main.scss */
+#preview-frame {
+  border: solid #aaa 1px;
+  width: 450px;
+  height: 300px;
+  background-color: #FFF;
+  padding: 0;
+  margin: 0;
+}
+
+/* line 76, ../sass/templates/main.scss */
+h4 {
+  font-size: 1em;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+  margin-bottom: 5px;
+  padding: 0;
+}


### PR DESCRIPTION
Rewrote preview to happen in an iframe, to ensure that strange embed code does not break the embed plugin.

Avoids using `HTMLInspector` on snippets that contain script tags, since it often gave false warnings on those.